### PR TITLE
Force flush to circumvent buffering from "compression" middleware

### DIFF
--- a/sse-server/sse-server.js
+++ b/sse-server/sse-server.js
@@ -68,6 +68,7 @@ function unregisterSubscriber(node, msg) {
   msg.res._res.write('event: close\n');
   msg.res._res.write(`data: The connection was closed by the server.\n`);
   msg.res._res.write(`id: ${msg._msgid}\n\n`);
+  msg.res._res.flush();
 
   // Remove the subscriber from the list
   node.subscribers = node.subscribers.filter((subscriber) => {

--- a/sse-server/sse-server.js
+++ b/sse-server/sse-server.js
@@ -34,7 +34,8 @@ function registerSubscriber(RED, node, msg) {
   msg.res._res.write('event: open\n');
   msg.res._res.write(`data: ${JSON.stringify(msg.payload || 'Connection opened')}\n`);
   msg.res._res.write(`id: ${msg._msgid}\n\n`);
-
+  msg.res._res.flush();
+  
   // Close a SSE connection when client disconnects
   msg.res._res.req.on('close', () => {
     updateNodeStatus(node, 'success');
@@ -69,7 +70,7 @@ function unregisterSubscriber(node, msg) {
   msg.res._res.write(`data: The connection was closed by the server.\n`);
   msg.res._res.write(`id: ${msg._msgid}\n\n`);
   msg.res._res.flush();
-
+  
   // Remove the subscriber from the list
   node.subscribers = node.subscribers.filter((subscriber) => {
     return subscriber.id !== msg._msgid;
@@ -94,6 +95,7 @@ function handleServerEvent(RED, node, msg) {
     subscriber.socket._res.write(`event: ${event}\n`);
     subscriber.socket._res.write(`data: ${data}\n`);
     subscriber.socket._res.write(`id: ${msg._msgid}\n\n`);
+    subscriber.socket._res.flush();
   });
 }
 


### PR DESCRIPTION
Some other contributed nodes (like [node-red-dashboard](https://github.com/node-red/node-red-dashboard)) might register middleware (like [compression](https://github.com/expressjs/compression)) that can change the behavior of sse-server.

This pull request [implements the recommended approach](https://github.com/expressjs/compression#server-sent-events) of flushing the buffer after writing the event.