### PR TITLE
Status output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+.vscode
+context_portal

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .vscode
 context_portal
+debug*

--- a/examples/example1.json
+++ b/examples/example1.json
@@ -80,14 +80,12 @@
       "name": "Subscribe to message server event",
       "url": "http://localhost:1880/subscribe",
       "event": "message",
-      "headers": [
-          {
-              "keyType": "other",
-              "keyValue": "x-api-token",
-              "valueType": "other",
-              "valueValue": "my-token"
-          }
-      ],
+      "headers": {
+          "keyType": "other",
+          "keyValue": "x-api-token",
+          "valueType": "other",
+          "valueValue": "my-token"
+      },
       "x": 180,
       "y": 180,
       "wires": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tq-bit/node-red-contrib-server-sent-events",
-  "version": "1.5.1",
+  "version": "1.5.2",
   "description": "Nodes to create - or subscribe to - server-sent events",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
   },
   "dependencies": {
     "eventsource": "2.0.2"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.10"
   }
 }

--- a/sse-client/sse-client.html
+++ b/sse-client/sse-client.html
@@ -10,7 +10,6 @@
       headers: { value: "" },
       maxConnectionAttempts: { value: "5" },
       connectionAttemptInterval: { value: "5000" },
-      reconnectOnClose: { value: "true" },
     },
     outputs: 1,
     icon: 'white-globe.svg',
@@ -51,24 +50,16 @@
 		<label for="node-input-connectionAttemptInterval"><i class="fa fa-clock-o"></i> Interval (ms) </label>
 		<input type="number" step="1000" min="1000" id="node-input-connectionAttemptInterval" />
 	</div>
-  <div class="form-row">
-    <label for="node-input-reconnectOnClose"></i> Retry on close</label>
-    <select type="text" id="node-input-reconnectOnClose">
-      <option value="true">Yes</option>
-      <option value="false">No</option>
-    </select>
-  </div>
-	<div class="form-tips">
+  <div class="form-tips">
     <p>
       Define an SSE endpoint to subscribe to. Variables are:
     </p>
     <ul>
       <li><code>URL</code> - The URL of the SSE endpoint to connect to</li>
       <li><code>Event</code> - The event name to subscribe to</li>
-      <li><code>Headers</code> - Optional headers to send with the request (as JSON)</li>
+      <li><code>Headers</code> - Optional headers to send with the request (as JSON object)</li>
       <li><code>Reconnect</code> - Maximum number of connection attempts on error (default: 5)</li>
       <li><code>Interval (ms)</code> - Time to wait between connection attempts (default: 5000ms)</li>
-      <li><code>Retry on close</code> - Whether to attempt reconnection when connection closes (Yes/No)</li>
     </ul>
 	</div>
 </script>
@@ -81,3 +72,4 @@
 		<a href="https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events">See @MDN Docs</a>
 	</p>
 </script>
+<script type="text/html" data-help-name="sse-server">   </script>

--- a/sse-client/sse-client.html
+++ b/sse-client/sse-client.html
@@ -65,11 +65,37 @@
 </script>
 
 <script type="text/html" data-help-name="sse-client">
-  <h2>SSE Clientside node</h2>
-	<p>Subscribe to a SSE - event stream using the <a href="https://www.npmjs.com/package/eventsource"><code>EventSource</code> API for Node.js</a>.</p>
-	<p>
-		Reference for Server Sent Events on the client side:
-		<a href="https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events">See @MDN Docs</a>
-	</p>
+  <h2>SSE Client Node</h2>
+  <p>
+    The <b>SSE Client</b> node allows you to subscribe to a Server-Sent Events (SSE) stream from a specified URL. It uses the <a href="https://www.npmjs.com/package/eventsource"><code>EventSource</code> API for Node.js</a> to connect to SSE endpoints and listen for real-time events.
+  </p>
+  <h3>How it works</h3>
+  <ul>
+    <li>Connects to the configured SSE endpoint URL and subscribes to the specified event type.</li>
+    <li>When an event is received, the node outputs a message with the event type as <code>msg.topic</code> and the event data as <code>msg.payload</code>.</li>
+    <li>If an error occurs or the connection is lost, the node will attempt to reconnect based on the configured retry settings.</li>
+    <li>Optional HTTP headers can be provided for authentication or custom requirements.</li>
+  </ul>
+  <h3>Configuration</h3>
+  <ul>
+    <li><b>URL</b>: The SSE endpoint to connect to (required).</li>
+    <li><b>Event</b>: The event name to listen for (required).</li>
+    <li><b>Headers</b>: Optional JSON object with HTTP headers.</li>
+    <li><b>Reconnect</b>: Maximum number of reconnection attempts if the connection fails (default: 5).</li>
+    <li><b>Interval (ms)</b>: Time in milliseconds to wait between reconnection attempts (default: 5000ms).</li>
+  </ul>
+  <h3>Outputs</h3>
+  <ul>
+    <li>On event: <code>msg.topic</code> contains the event type, <code>msg.payload</code> contains the event data.</li>
+  </ul>
+  <h3>References</h3>
+  <ul>
+    <li>
+      <a href="https://www.npmjs.com/package/eventsource"><code>EventSource</code> API for Node.js</a>
+    </li>
+    <li>
+      <a href="https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events">MDN: Using server-sent events</a>
+    </li>
+  </ul>
 </script>
 <script type="text/html" data-help-name="sse-server">   </script>

--- a/sse-client/sse-client.js
+++ b/sse-client/sse-client.js
@@ -99,27 +99,28 @@ function connect(RED, node, config) {
  */
 function handleEventSourceClose(RED, node, config) {
   RED.log.debug(`Closing event source: ${node.url}`);
-  node.eventSource.close();
+    node.eventSource.close();
+    node.eventSource = null;
 
-  if (node.reconnectOnClose) {
-    RED.log.warn(
-      `Lost connection to ${node.url} - Reconnecting in ${
-        (node.connectionAttemptInterval * (node._counter + 1)) / 1000
-      } seconds`
-    );
-    node._counter = node._counter + 1;
-    node.status({
-      fill: "yellow",
-      shape: "dot",
-      text: `Lost connection to ${node.url} - Reconnecting in ${
-        (node.connectionAttemptInterval * (node._counter + 1)) / 1000
-      } seconds`,
-    });
-    setTimeout(
-      () => connect(RED, node, config),
-      node.connectionAttemptInterval * (node._counter + 1)
-    );
-  }
+//   if (node.reconnectOnClose) {
+//     RED.log.warn(
+//       `Lost connection to ${node.url} - Reconnecting in ${
+//         (node.connectionAttemptInterval * (node._counter + 1)) / 1000
+//       } seconds`
+//     );
+//     node._counter = node._counter + 1;
+//     node.status({
+//       fill: "yellow",
+//       shape: "dot",
+//       text: `Lost connection to ${node.url} - Reconnecting in ${
+//         (node.connectionAttemptInterval * (node._counter + 1)) / 1000
+//       } seconds`,
+//     });
+//     setTimeout(
+//       () => connect(RED, node, config),
+//       node.connectionAttemptInterval * (node._counter + 1)
+//     );
+//   }
 }
 
 module.exports = function (RED) {

--- a/sse-client/sse-client.js
+++ b/sse-client/sse-client.js
@@ -97,7 +97,7 @@ function connect(RED, node, config) {
  * @param {Object} node - The node instance that the function is called on.
  * @return {void}
  */
-function handleEventSourceClose(RED, node, config) {
+function handleEventSourceClose(RED, node, _config) {
   RED.log.debug(`Closing event source: ${node.url}`);
     node.eventSource.close();
     node.eventSource = null;

--- a/sse-server/sse-server.html
+++ b/sse-server/sse-server.html
@@ -45,11 +45,86 @@
 </script>
 
 <script type="text/html" data-help-name="sse-server">
-  <h2>SSE Serverside node</h2>
-	<p>Open an SSE - event stream to a connected client. This node must originate from a default <code>http-in</code> node.</p>
+  <h2>SSE Server Node</h2>
   <p>
-    To connect from a client, you can use the <code>sse-client</code> node from this module or the
-    <code>EventSource</code> API.
+    The <b>SSE Server</b> node enables you to create a Server-Sent Events (SSE) endpoint in your Node-RED flow. It allows you to push real-time updates from your server to connected clients over HTTP, using the SSE protocol.
   </p>
-
+  <h3>How it works</h3>
+  <ul>
+    <li>
+      <b>Connection Handling:</b> When a client connects (typically via an <code>http-in</code> node), the SSE Server node registers the client as a subscriber and opens an SSE stream. The node keeps track of all active subscribers.
+    </li>
+    <li>
+      <b>Sending Events:</b> When the node receives a message without a <code>res</code> property, it broadcasts an event to all connected clients. The event type defaults to the <code>event</code> property (or <code>msg.topic</code>), and the data defaults to the <code>data</code> property (or <code>msg.payload</code>).
+    </li>
+    <li>
+      <b>Disconnection:</b> When a client disconnects, the node cleans up the subscriber and emits a <code>disconnect</code> event.
+    </li>
+    <li>
+      <b>Status:</b> The node displays the number of currently connected clients in the Node-RED editor.
+    </li>
+  </ul>
+  <h3>Typical Usage</h3>
+  <ol>
+    <li>
+      Start with an <code>http-in</code> node to define the endpoint URL (e.g., <code>/events</code>).
+    </li>
+    <li>
+      Connect the <code>http-in</code> node to the <b>SSE Server</b> node.
+    </li>
+    <li>
+      Optionally, use a <code>function</code> or other nodes to generate messages you want to broadcast.
+    </li>
+    <li>
+      Connect the <b>SSE Server</b> node to an <code>http-response</code> node to complete the HTTP flow.
+    </li>
+  </ol>
+  <h3>Configuration</h3>
+  <ul>
+    <li>
+      <b>Event:</b> The name of the event to send. By default, this is taken from the incoming message's <code>msg.topic</code> property.
+    </li>
+    <li>
+      <b>Data:</b> The content to send to clients. By default, this is taken from the incoming message's <code>msg.payload</code> property. The payload can be a string or a JSON object; if it is an object, it will be automatically serialized to JSON before being sent.
+    </li>
+    <li>
+      <b>Name:</b> Optional label for the node.
+    </li>
+  </ul>
+  <p>
+    <b>Note:</b> When sending a message to this node, set <code>msg.topic</code> to define the event name, and <code>msg.payload</code> to define the event content (which can be a JSON object).
+  </p>
+  <h3>Client Connection</h3>
+  <p>
+    Clients can connect using the <code>sse-client</code> node from this module or any standard SSE client such as the browser's <code>EventSource</code> API:
+  </p>
+  <pre>
+const eventSource = new EventSource('/events');
+eventSource.addEventListener('new-message', (event) => {
+  try {
+      const packet = JSON.parse(event.data);
+      console.log(packet.displayName);
+  } catch (e) {
+      console.error('Invalid JSON:', e);
+  }
+});
+  </pre>
+  <h3>Notes</h3>
+  <ul>
+    <li>
+      This node must always originate from an <code>http-in</code> node.
+    </li>
+    <li>
+      Each new HTTP connection is registered as a subscriber and will receive all broadcast events until the connection is closed.
+    </li>
+    <li>
+      On redeploy or shutdown, all client connections are closed gracefully.
+    </li>
+  </ul>
+  <h3>Related Nodes</h3>
+  <ul>
+    <li>
+      <b>sse-client</b>: Use this node to receive SSE events in Node-RED flows.
+    </li>
+  </ul>
 </script>

--- a/sse-server/sse-server.html
+++ b/sse-server/sse-server.html
@@ -10,6 +10,7 @@
     },
     align: 'right',
     inputs: 1,
+    outputs: 1,
     icon: 'white-globe.svg',
     label: function () {
       return this.name || 'sse-server';

--- a/sse-server/sse-server.js
+++ b/sse-server/sse-server.js
@@ -48,12 +48,12 @@ function registerSubscriber(RED, node, msg) {
 	// Emit output message on client connect
 	if (typeof node.send === 'function') {
 		node.send({
-			payload: msg.payload || 'Client connected',
-			event: 'connect',
-			_msgid: msg._msgid,
-			req: msg.req,
-			res: msg.res
-		});
+            payload: {
+                event: 'connect',
+            },
+            req: msg.req,
+            res: msg.res,
+        });
 	}
 
 	// Close a SSE connection when client disconnects
@@ -88,8 +88,9 @@ function unregisterSubscriber(node, msg) {
 	// Emit output message on client disconnect
 	if (typeof node.send === 'function') {
 		node.send({
-			payload: 'Client disconnected',
-			event: 'disconnect',
+            payload: {
+                event: 'disconnect'
+            },
 			_msgid: msg._msgid,
 			req: msg.req,
 			res: msg.res

--- a/sse-server/sse-server.js
+++ b/sse-server/sse-server.js
@@ -46,15 +46,10 @@ function registerSubscriber(RED, node, msg) {
 	if (msg.res._res.flush) msg.res._res.flush();
 
 	// Emit output message on client connect
-	if (typeof node.send === 'function') {
-		node.send({
-            payload: {
-                event: 'connect',
-            },
-            req: msg.req,
-            res: msg.res,
-        });
-	}
+    msg.payload = {
+        event: 'connect',
+    };
+	node.send(msg);
 
 	// Close a SSE connection when client disconnects
 	msg.res._res.req.on('close', () => {
@@ -86,16 +81,10 @@ function unregisterSubscriber(node, msg) {
 	if (msg.res._res.flush) msg.res._res.flush();
 
 	// Emit output message on client disconnect
-	if (typeof node.send === 'function') {
-		node.send({
-            payload: {
-                event: 'disconnect'
-            },
-			_msgid: msg._msgid,
-			req: msg.req,
-			res: msg.res
-		});
-	}
+    msg.payload = {
+        event: 'disconnect',
+    };
+    node.send(msg);
 
 	// Remove the subscriber from the list
 	node.subscribers = node.subscribers.filter((subscriber) => {

--- a/sse-server/sse-server.js
+++ b/sse-server/sse-server.js
@@ -45,6 +45,17 @@ function registerSubscriber(RED, node, msg) {
 	msg.res._res.write(`id: ${msg._msgid}\n\n`);
 	if (msg.res._res.flush) msg.res._res.flush();
 
+	// Emit output message on client connect
+	if (typeof node.send === 'function') {
+		node.send({
+			payload: msg.payload || 'Client connected',
+			event: 'connect',
+			_msgid: msg._msgid,
+			req: msg.req,
+			res: msg.res
+		});
+	}
+
 	// Close a SSE connection when client disconnects
 	msg.res._res.req.on('close', () => {
 		unregisterSubscriber(node, msg);
@@ -73,6 +84,17 @@ function unregisterSubscriber(node, msg) {
 	msg.res._res.write(`data: The connection was closed by the server.\n`);
 	msg.res._res.write(`id: ${msg._msgid}\n\n`);
 	if (msg.res._res.flush) msg.res._res.flush();
+
+	// Emit output message on client disconnect
+	if (typeof node.send === 'function') {
+		node.send({
+			payload: 'Client disconnected',
+			event: 'disconnect',
+			_msgid: msg._msgid,
+			req: msg.req,
+			res: msg.res
+		});
+	}
 
 	// Remove the subscriber from the list
 	node.subscribers = node.subscribers.filter((subscriber) => {


### PR DESCRIPTION
Hi,

I added output messages to the SSE server node to signal when a client connects or disconnects. This helps track client activity and enables flows to react to these events.
I removed the "Reconnect on Close" parameter from the SSE client node. Previously, this could leave a lingering instance with an open connection when the node was destroyed. Removing it ensures proper cleanup.
I expanded and clarified the documentation for both the SSE client and server nodes. The help sections now provide more detailed usage instructions, configuration options, and examples to make the nodes easier to use and understand.

Regards