### PR TITLE
Changed event-type and event-data to typed, added routing option

### DIFF
--- a/sse-server/sse-server.html
+++ b/sse-server/sse-server.html
@@ -4,9 +4,9 @@
     name: 'sse-server',
     color: '#4693c8',
     defaults: {
-      name: { value: '', type: 'string' },
-      event: { value: '', type: 'string' },
-      data: { value: '', type: 'string' },
+      name: { value: 'sse-server', type: 'string' },
+      event: { value: 'topic' },
+      data: { value: 'payload' },
     },
     align: 'right',
     inputs: 1,
@@ -15,22 +15,36 @@
     label: function () {
       return this.name || 'sse-server';
     },
+    oneditprepare: function() {
+      $("#node-input-event").typedInput({
+        type:"msg",
+        types:["msg"],
+        typeField: "#node-input-event-type"
+      })
+      $("#node-input-data").typedInput({
+        type:"msg",
+        types:["msg"],
+        typeField: "#node-input-data-type"
+      })
+
+    }
   });
 </script>
 
 <script type="text/html" data-template-name="sse-server">
-	<div class="form-row">
-		<label for="node-input-event"><i class="fa fa-wifi"></i> Event </label>
-		<input placeholder="msg.topic" type="text" id="node-input-event" />
-	</div>
+  <div class="form-row">
+    <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
+    <input type="text" id="node-input-name">
+  </div>
+  <div class="form-row">
+      <label for="node-input-event"><i class="fa fa-wifi"></i> Event </label>
+      <input type="text" id="node-input-event">
+      <input type="hidden" id="node-input-event-type">
   </div>
   <div class="form-row">
     <label for="node-input-data"><i class="fa fa-cube"></i> Data </label>
-    <input placeholder="msg.payload" type="text" id="node-input-data" />
-  </div>
-  <div class="form-row">
-    <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
-    <input placeholder="sse-server" type="text" id="node-input-name" />
+    <input type="text" id="node-input-data">
+    <input type="hidden" id="node-input-data-type">
   </div>
 	<div class="form-tips">
     <p>

--- a/sse-server/sse-server.html
+++ b/sse-server/sse-server.html
@@ -7,6 +7,9 @@
       name: { value: 'sse-server', type: 'string' },
       event: { value: 'topic' },
       data: { value: 'payload' },
+      route: { value: false },
+      routeKey: { value: 'route' },
+      broadcastKey: { value: 'broadcast' }
     },
     align: 'right',
     inputs: 1,
@@ -26,7 +29,21 @@
         types:["msg"],
         typeField: "#node-input-data-type"
       })
-
+      $("#node-input-route").typedInput({
+        type:"bool",
+        types:["bool"],
+        typeField: "#node-input-route-type"
+      })
+      $("#node-input-routeKey").typedInput({
+        type:"msg",
+        types:["msg"],
+        typeField: "#node-input-routeKey-type"
+      })
+      $("#node-input-broadcastKey").typedInput({
+        type:"msg",
+        types:["msg"],
+        typeField: "#node-input-broadcastKey-type"
+      })
     }
   });
 </script>
@@ -46,16 +63,37 @@
     <input type="text" id="node-input-data">
     <input type="hidden" id="node-input-data-type">
   </div>
-	<div class="form-tips">
+  <div class="form-row">
+    <label for="node-input-route"><i class="fa fa-split"></i> Route </label>
+    <input type="text" id="node-input-route">
+    <input type="hidden" id="node-input-route-type">
+  </div>
+  <div class="form-row">
+    <label for="node-input-routeKey"><i class="fa fa-key"></i> Route Key</label>
+    <input type="text" id="node-input-routeKey">
+    <input type="hidden" id="node-input-routeKey-type">
+  </div>
+
+  <div class="form-row">
+    <label for="node-input-broadcastKey"><i class="fa fa-key"></i> Broadcast Key</label>
+    <input type="text" id="node-input-broadcastKey">
+    <input type="hidden" id="node-input-broadcastKey-type">
+  </div>
+  <div class="form-tips">
     <p>
       Define an event name and a payload to send to all subscribed clients of this HTTP endpoint. By
       default, `msg.topic` will be used to declare the event's <code>type</code>, <code>msg.payload</code> will be stringified and
       send as the event's <code>data</code> property.
     </p>
+    <p>
+      You can use this node as either a broadcast node, or a route node. By default, it acts as a broadcast : every SSE subscriber will
+      receive all events. If you enable <code>route</code>, only the subscribers that used the same <code>route key</code> at
+      subscribe time will receive those events, unless the <code>broadcast</code> flag is set to true.
+    </p>
     <b>
       This node must always origin from an 'http in' node
     </b>
-	</div>
+  </div>
 </script>
 
 <script type="text/html" data-help-name="sse-server">
@@ -104,9 +142,21 @@
     <li>
       <b>Name:</b> Optional label for the node.
     </li>
+    <li>
+      <b>Route:</b> Enable routing mode
+    </li>
+    <li>
+      <b>Route Key:</b> Defines which message property is used for routing (default: <code>msg.route</code>).
+    </li>
+    <li>
+      <b>Broadcast Key:</b> Defines which message property is used for broadcasting (default: <code>msg.broadcast</code>). This property should either be true or false, and will default to false. It will have no effect if <code>Route</code> is disabled.
+    </li>
   </ul>
   <p>
     <b>Note:</b> When sending a message to this node, set <code>msg.topic</code> to define the event name, and <code>msg.payload</code> to define the event content (which can be a JSON object).
+  </p>
+  <p>
+    <b>Note:</b> When Route is enabled, the configured route key must exist and not be empty on incoming messages.
   </p>
   <h3>Client Connection</h3>
   <p>

--- a/sse-server/sse-server.js
+++ b/sse-server/sse-server.js
@@ -112,9 +112,10 @@ function unregisterSubscriber(node, msg) {
  * @param {object} node - The node object containing subscribers and event data.
  * @param {object} msg - The message object containing topic and payload.
  */
-function handleServerEvent(RED, node, msg) {
-	const event = `${node.event || msg.topic || 'message'}`;
-	const data = `${_serializeData(node.data || msg.payload)}`;
+function handleServerEvent(RED, node, msg, eventValue, dataValue) {
+	const event = eventValue ||'message';
+	const data = (typeof dataValue ==='string') ? dataValue : JSON.stringify(dataValue);
+
 	RED.log.debug(`Sent event: ${event}`);
 	RED.log.debug(`Data: ${data}`);
 	node.subscribers = node.subscribers.filter((subscriber) => {
@@ -158,10 +159,12 @@ module.exports = function (RED) {
 		/**@ts-ignore */
 		this.on('input', (msg, send, done) => {
 			try {
+				const eventValue = RED.util.getMessageProperty(msg, this.event);
+				const dataValue = RED.util.getMessageProperty(msg, this.data);
 				if (msg.res) {
 					registerSubscriber(RED, this, msg);
 				} else {
-					handleServerEvent(RED, this, msg);
+					handleServerEvent(RED, this, msg, eventValue, dataValue);
 				}
 			} catch (error) {
 				RED.log.error(error);

--- a/sse-server/sse-server.js
+++ b/sse-server/sse-server.js
@@ -38,6 +38,7 @@ function registerSubscriber(RED, node, msg) {
 		'Cache-Control': 'no-cache',
 		Connection: 'keep-alive',
 	});
+	const routeKeyValue = RED.util.getMessageProperty(msg, node.routeKey);
 
 	// Write the initial opening message
 	msg.res._res.write('event: open\n');
@@ -65,6 +66,7 @@ function registerSubscriber(RED, node, msg) {
 		node.subscribers.push({
 			id: msg._msgid,
 			socket: msg.res,
+			routeKey: routeKeyValue
 		});
 	}
 	updateNodeStatus(node, 'success');
@@ -112,14 +114,24 @@ function unregisterSubscriber(node, msg) {
  * @param {object} node - The node object containing subscribers and event data.
  * @param {object} msg - The message object containing topic and payload.
  */
-function handleServerEvent(RED, node, msg, eventValue, dataValue) {
+function handleServerEvent(RED, node, msg, eventValue, dataValue, routeValue, routeKeyValue, broadcastKeyValue) {
 	const event = eventValue ||'message';
 	const data = (typeof dataValue ==='string') ? dataValue : JSON.stringify(dataValue);
 
+	const mustRoute = routeValue || false;
+	const route = routeKeyValue || 'route';
+	const broadcast = broadcastKeyValue === true || false;
+
+
 	RED.log.debug(`Sent event: ${event}`);
 	RED.log.debug(`Data: ${data}`);
+	RED.log.debug(`Route: ${mustRoute}, to: ${route}, broadcast: ${broadcast}`);
 	node.subscribers = node.subscribers.filter((subscriber) => {
 		try {
+			if(mustRoute && !broadcast) {
+				if(route === undefined || subscriber.routeKey !== route) return true; //Keep sub, send nothing
+
+			}
 			subscriber.socket._res.write(`event: ${event}\n`);
 			subscriber.socket._res.write(`data: ${data}\n`);
 			subscriber.socket._res.write(`id: ${msg._msgid}\n\n`);
@@ -155,16 +167,22 @@ module.exports = function (RED) {
 		this.subscribers = [];
 		this.event = config.event;
 		this.data = config.data;
+		this.route = config.route;
+		this.routeKey = config.routeKey;
+		this.broadcastKey = config.broadcastKey;
 
 		/**@ts-ignore */
 		this.on('input', (msg, send, done) => {
 			try {
 				const eventValue = RED.util.getMessageProperty(msg, this.event);
 				const dataValue = RED.util.getMessageProperty(msg, this.data);
+				const routeValue = this.route === true || this.route==="true";
+				const routeKeyValue = RED.util.getMessageProperty(msg, this.routeKey);
+				const broadcastKeyValue = RED.util.getMessageProperty(msg, this.broadcastKey);
 				if (msg.res) {
 					registerSubscriber(RED, this, msg);
 				} else {
-					handleServerEvent(RED, this, msg, eventValue, dataValue);
+					handleServerEvent(RED, this, msg, eventValue, dataValue, routeValue, routeKeyValue, broadcastKeyValue);
 				}
 			} catch (error) {
 				RED.log.error(error);


### PR DESCRIPTION
This PR does two things :
- the sse-server node now allows you to choose a routing key, so you can send messages only to specific subscribers
- the node editor has been cleaned up and made more consistent with other Node-Red nodes, simplifying validation

Right now, every SSE subscriber will receive every message. This works well if that's what you want to happen, but scales very poorly if you need any kind of data filtering when sending. 

This change allows you to either keep the current broadcast working mode as it is, or to enable routing.

When routing is enabled, messages are only sent to subscribers that used the same "route key" when subscribing as your messages is using, unless they are flagged as "broadcast" in the message (using the Broadcast key).

As an example, let's say I have clients that subscribe with `/sub?client=john-doe`. You could setup the `sse-server` node by using a function in between that gets that client ID and puts it in `msg.route`.

<img width="1309" height="360" alt="image" src="https://github.com/user-attachments/assets/4aef3c4c-de99-40c6-85a2-e5ee8b874537" />

The subscriber will have "john-doe" recorded as routing key.

Now, if you send any message to subscribers, the one that used "john-doe" as key will only receive messages that have the same `msg.route`, or have their broadcast flag set to true.

Example inputs : 
```json
{
  topic: "message",
  route: "john-doe",
  payload: "Hello, John!"
}
```

```json
{
  topic: "message",
  route: "hans-gruber",
  payload: "Hello, Hans!"
}
```

```json
{
  topic: "message",
  payload: "Hello, you!"
}
```

```json
{
  topic: "message",
  broadcast: true,
  payload: "Hello, world!"
}
```

In those messages, the subscribers using the `john-doe` route will receive : "Hello, John!" and "Hello, world!" only. Any subscriber of `hans-gruber` will obviously receive "Hello, Hans!".

This was needed for me to have some JWT validation on the server-side. The clients can register to whichever URL they wish, but I validate their token with a JWT and remove any route that is not specifically included in their JWT roles.



Lastly, a screenshot of how the editor UI changes : 
from

<img width="569" height="179" alt="image" src="https://github.com/user-attachments/assets/c3f7cedd-d80c-49c5-bdac-27f56a66d763" />

to
<img width="506" height="632" alt="image" src="https://github.com/user-attachments/assets/d772ecd5-a9ad-4b6d-83f3-f917c89db619" />

